### PR TITLE
Ajoute une alternative à la commande proposée

### DIFF
--- a/faq-7.2-install-config.md
+++ b/faq-7.2-install-config.md
@@ -147,7 +147,7 @@ $ git config --global user.email you@yourdomain.example.com
 ```
 $ git remote set-url origin https://domain.tld/repo.git
 # ou
-git remote add origin https://domain.tld/repo.git
+$ git remote add origin https://domain.tld/repo.git
 ```
 
 A pour effet de changer l'url pour le `fetch` et pour le `push`.


### PR DESCRIPTION
La commande

```bash
git remote add origin https://domain.tld/repo.git
```
adopte le même comportement que `git remote set-url`. Elle modifie également l'url du `fetch` et du `push`.